### PR TITLE
fix: re-fetch secret UID/ResourceVersion before Update to prevent precondition failure

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,7 @@ github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkg
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/evanphx/json-patch v0.0.0-20190203023257-5858425f7550/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6vRfwrJatElLBEf0I=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -199,6 +200,7 @@ google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEt
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+google.golang.org/appengine v1.6.5 h1:tycE03LOZYQNhDpS27tcQdAzLCVMaj7QT2SXxebnpCM=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
@@ -234,6 +236,7 @@ k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a/go.mod h1:1TqjTSzOxsLGIKfj0lK8EeCP7K1iUG65v09OM0/WG5E=
+k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c h1:/KUFqjjqAcY4Us6luF5RDNZ16KJtb49HfR3ZHB9qYXM=
 k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
 k8s.io/utils v0.0.0-20190221042446-c2654d5206da/go.mod h1:8k8uAuAQ0rXslZKaEWd0c3oVhZz7sSzSiPnVZayjIX0=
 k8s.io/utils v0.0.0-20200229041039-0a110f9eb7ab h1:I3f2hcBrepGRXI1z4sukzAb8w1R4eqbsHrAsx06LGYM=

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -27,6 +27,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 )
 
 type Secret struct {
@@ -197,26 +198,39 @@ func (s *Secret) Set(key string, val string) (err error) {
 func (s *Secret) UpdateObject(cli kubernetes.Interface) (result *v1.Secret, err error) {
 	log.Info("Updating Kubernetes Secret...")
 
-	// Re-fetch the current version of the secret immediately before calling
-	// Update. The controller builds its work list from a point-in-time List
-	// snapshot; if the secret is deleted and recreated between that snapshot
-	// and this Update call, the stale UID in s.Secret will no longer match
-	// the UID held in etcd, causing:
+	// Wrap the Get+Update in RetryOnConflict to handle the race window between
+	// reading the current ResourceVersion and writing the update.  Kubernetes
+	// uses optimistic concurrency: if any other actor modifies the secret
+	// between our Get and our Update the API server returns HTTP 409 Conflict:
+	//
+	//   the object has been modified; please apply your changes to the latest
+	//   version and try again
+	//
+	// RetryOnConflict detects that error and retries up to 5 times with
+	// exponential back-off (10 ms … 1 s).
+	//
+	// Inside the retry loop we also re-fetch the live ResourceVersion and UID
+	// before every Update attempt.  The controller builds its work list from a
+	// point-in-time List snapshot; if the secret is deleted and recreated
+	// between that snapshot and this call, the stale UID would trigger:
 	//
 	//   StorageError: invalid object, Code: 4
 	//   Precondition failed: UID in precondition: <old>, UID in object meta: <new>
-	//
-	// By re-fetching we always carry the live ResourceVersion (optimistic
-	// concurrency) and the live UID (precondition check) into the Update.
-	current, getErr := cli.CoreV1().Secrets(s.Namespace).Get(s.Name, metav1.GetOptions{})
-	if getErr != nil {
-		return nil, fmt.Errorf("failed to get current secret %s/%s before update: %v", s.Namespace, s.Name, getErr)
-	}
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, getErr := cli.CoreV1().Secrets(s.Namespace).Get(s.Name, metav1.GetOptions{})
+		if getErr != nil {
+			return fmt.Errorf("failed to get current secret %s/%s before update: %v", s.Namespace, s.Name, getErr)
+		}
 
-	s.Secret.ResourceVersion = current.ResourceVersion
-	s.Secret.UID = current.UID
+		s.Secret.ResourceVersion = current.ResourceVersion
+		s.Secret.UID = current.UID
 
-	return cli.CoreV1().Secrets(s.Namespace).Update(&s.Secret)
+		var updateErr error
+		result, updateErr = cli.CoreV1().Secrets(s.Namespace).Update(&s.Secret)
+		return updateErr
+	})
+
+	return result, retryErr
 }
 
 func safeKeyName(key string) string {

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -25,6 +25,7 @@ import (
 	anno "github.com/cmattoon/aws-ssm/pkg/annotations"
 	"github.com/cmattoon/aws-ssm/pkg/provider"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -195,6 +196,26 @@ func (s *Secret) Set(key string, val string) (err error) {
 
 func (s *Secret) UpdateObject(cli kubernetes.Interface) (result *v1.Secret, err error) {
 	log.Info("Updating Kubernetes Secret...")
+
+	// Re-fetch the current version of the secret immediately before calling
+	// Update. The controller builds its work list from a point-in-time List
+	// snapshot; if the secret is deleted and recreated between that snapshot
+	// and this Update call, the stale UID in s.Secret will no longer match
+	// the UID held in etcd, causing:
+	//
+	//   StorageError: invalid object, Code: 4
+	//   Precondition failed: UID in precondition: <old>, UID in object meta: <new>
+	//
+	// By re-fetching we always carry the live ResourceVersion (optimistic
+	// concurrency) and the live UID (precondition check) into the Update.
+	current, getErr := cli.CoreV1().Secrets(s.Namespace).Get(s.Name, metav1.GetOptions{})
+	if getErr != nil {
+		return nil, fmt.Errorf("failed to get current secret %s/%s before update: %v", s.Namespace, s.Name, getErr)
+	}
+
+	s.Secret.ResourceVersion = current.ResourceVersion
+	s.Secret.UID = current.UID
+
 	return cli.CoreV1().Secrets(s.Namespace).Update(&s.Secret)
 }
 

--- a/pkg/secret/secret_test.go
+++ b/pkg/secret/secret_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestParseStringList(t *testing.T) {
@@ -248,6 +250,77 @@ func TestFromKubernetesSecretUsesSpecifiedEncryptionKey(t *testing.T) {
 	if err != nil || ks.ParamKey != "foo/bar/baz" || ks.ParamValue != "FooBar123" {
 		t.Fail()
 	}
+}
+
+// TestUpdateObjectRefetchesUID verifies that UpdateObject re-fetches the
+// current secret before calling Update so that a stale UID (held in the
+// in-memory snapshot from a previous List call) is replaced with the live
+// UID from the API server.  Without the fix this would fail with:
+//
+//	StorageError: invalid object, Code: 4
+//	Precondition failed: UID in precondition: <old>, UID in object meta: <new>
+func TestUpdateObjectRefetchesUID(t *testing.T) {
+	const namespace = "test-ns"
+	const name = "my-secret"
+	const staleUID types.UID = "stale-uid-from-list-snapshot"
+	const currentUID types.UID = "current-uid-after-recreate"
+	const currentRV = "42"
+
+	// The secret that currently lives in the API server (new UID after a
+	// delete+recreate cycle).
+	liveSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       namespace,
+			UID:             currentUID,
+			ResourceVersion: currentRV,
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset(liveSecret)
+
+	// Build an internal Secret that carries the *stale* snapshot UID –
+	// exactly the situation that causes the precondition failure.
+	s := &Secret{
+		Name:      name,
+		Namespace: namespace,
+		Secret: v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				UID:       staleUID, // stale – would trigger UID mismatch without fix
+			},
+			StringData: map[string]string{"mykey": "myvalue"},
+		},
+	}
+
+	result, err := s.UpdateObject(fakeClient)
+	require.NoError(t, err, "UpdateObject should succeed even when the in-memory UID is stale")
+	assert.Equal(t, currentUID, result.UID, "result should carry the live UID")
+	assert.Equal(t, currentRV, result.ResourceVersion, "result should carry the live ResourceVersion")
+	assert.Equal(t, "myvalue", result.StringData["mykey"], "SSM value should be written to the secret")
+}
+
+// TestUpdateObjectReturnsErrorWhenSecretGone verifies that UpdateObject
+// returns a meaningful error when the secret no longer exists (i.e. was
+// deleted and not yet recreated).
+func TestUpdateObjectReturnsErrorWhenSecretGone(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset() // empty – no secrets
+
+	s := &Secret{
+		Name:      "missing-secret",
+		Namespace: "test-ns",
+		Secret: v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "missing-secret",
+				Namespace: "test-ns",
+			},
+		},
+	}
+
+	_, err := s.UpdateObject(fakeClient)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get current secret")
 }
 
 func TestSafeKeyName(t *testing.T) {


### PR DESCRIPTION
## Issue

**File:** `pkg/secret/secret.go` — `UpdateObject()`

**Two distinct error types were observed in production logs:**

### 1. Stale snapshot UID / precondition failure (StorageError Code 4)

The controller's reconciliation loop works in two steps:

1. `HandleSecrets` calls `cli.CoreV1().Secrets("").List(...)` — this produces a **point-in-time snapshot** of every secret. Each snapshot object carries the UID and ResourceVersion that existed *at that instant*.
2. For every annotated secret, the controller fetches the value from AWS SSM (network I/O), then calls `UpdateObject` which submitted the stale snapshot object directly to the API server.

If the secret is **deleted and recreated** between steps 1 and 2 (e.g. by a CI/CD pipeline, Helm, or Terraform), the secret gets a new UID in etcd. The controller's update would then be rejected with:

```
StorageError: invalid object, Code: 4
Precondition failed: UID in precondition: 2fcef3a2-... (old), UID in object meta: 0571b0df-... (new)
```

### 2. Optimistic concurrency conflict (HTTP 409)

Even with a live `Get` immediately before `Update`, there is an unavoidable race window between those two calls. If any other actor modifies the secret in that gap, the API server rejects the update with:

```
the object has been modified; please apply your changes to the latest version and try again
```

---

## Fix

**Branch:** `fix/uid-precondition-stale-snapshot`  
**Commits:** `8f171df` → `c28ff0e`

Both error types are addressed in `UpdateObject` by wrapping the Get+Update in `retry.RetryOnConflict`:

```go
func (s *Secret) UpdateObject(cli kubernetes.Interface) (result *v1.Secret, err error) {
    log.Info("Updating Kubernetes Secret...")

    // Wrap the Get+Update in RetryOnConflict to handle the race window between
    // reading the current ResourceVersion and writing the update. Kubernetes
    // uses optimistic concurrency: if any other actor modifies the secret
    // between our Get and our Update the API server returns HTTP 409 Conflict:
    //
    //   the object has been modified; please apply your changes to the latest
    //   version and try again
    //
    // RetryOnConflict detects that error and retries up to 5 times with
    // exponential back-off (10 ms ... 1 s).
    //
    // Inside the retry loop we also re-fetch the live ResourceVersion and UID
    // before every Update attempt. The controller builds its work list from a
    // point-in-time List snapshot; if the secret is deleted and recreated
    // between that snapshot and this call, the stale UID would trigger:
    //
    //   StorageError: invalid object, Code: 4
    //   Precondition failed: UID in precondition: <old>, UID in object meta: <new>
    retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
        current, getErr := cli.CoreV1().Secrets(s.Namespace).Get(s.Name, metav1.GetOptions{})
        if getErr != nil {
            return fmt.Errorf("failed to get current secret %s/%s before update: %v", s.Namespace, s.Name, getErr)
        }

        s.Secret.ResourceVersion = current.ResourceVersion
        s.Secret.UID = current.UID

        var updateErr error
        result, updateErr = cli.CoreV1().Secrets(s.Namespace).Update(&s.Secret)
        return updateErr
    })

    return result, retryErr
}
```

**Why this works:**

| Error type | Root cause | Fix |
|---|---|---|
| `StorageError Code 4 / UID precondition failed` | Stale UID from List() snapshot (secret delete+recreate) | Re-fetch live UID before every Update attempt |
| `object has been modified` (HTTP 409) | Get→Update race with concurrent modifications | `retry.RetryOnConflict` retries up to 5× with exponential back-off (10 ms–1 s) |

- If the secret was deleted and not yet recreated, `Get` returns a 404 and a clear error is surfaced immediately instead of a cryptic StorageError.
- No new dependencies — `k8s.io/client-go/util/retry` is already present in `go.mod`.

All tests pass (`go test ./...` — ok on all packages).

---