### PR TITLE
fix: paginate through all secrets in HandleSecrets

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -53,34 +53,51 @@ func NewController(cfg *config.Config) *Controller {
 }
 
 func (c *Controller) HandleSecrets(cli kubernetes.Interface) error {
-	secrets, err := cli.CoreV1().Secrets("").List(metav1.ListOptions{})
-	if err != nil {
-		log.Fatalf("Error retrieving secrets: %s", err)
-	}
-
+	// The Kubernetes API server paginates list responses (default page size:
+	// 500). Without explicit pagination the controller would silently process
+	// only the first 500 secrets out of potentially tens of thousands, leaving
+	// the remainder permanently un-synced.  We follow the Continue token until
+	// all pages have been consumed.
+	var continueToken string
 	i, j, k := 0, 0, 0
-	for _, sec := range secrets.Items {
-		i++
 
-		obj, err := secret.FromKubernetesSecret(c.Provider, sec)
+	for {
+		secrets, err := cli.CoreV1().Secrets("").List(metav1.ListOptions{
+			Limit:    500,
+			Continue: continueToken,
+		})
 		if err != nil {
-			// Error: Irrelevant Secret
-			continue
+			log.Fatalf("Error retrieving secrets: %s", err)
 		}
-		j++
 
-		_, err = obj.UpdateObject(cli)
-		if err != nil {
-			log.Warnf("Failed to update object %s/%s", obj.Namespace, obj.Name)
-			log.Warn(err.Error())
-			continue
+		for _, sec := range secrets.Items {
+			i++
+
+			obj, err := secret.FromKubernetesSecret(c.Provider, sec)
+			if err != nil {
+				// Error: Irrelevant Secret
+				continue
+			}
+			j++
+
+			_, err = obj.UpdateObject(cli)
+			if err != nil {
+				log.Warnf("Failed to update object %s/%s", obj.Namespace, obj.Name)
+				log.Warn(err.Error())
+				continue
+			}
+			log.Infof("Successfully updated %s/%s", obj.Namespace, obj.Name)
+			k++
 		}
-		log.Infof("Successfully updated %s/%s", obj.Namespace, obj.Name)
-		k++
+
+		if secrets.Continue == "" {
+			break
+		}
+		continueToken = secrets.Continue
 	}
 
 	log.Infof("Updated %v/%v secrets (of %v total secrets)", k, j, i)
-	return err
+	return nil
 }
 
 func (c *Controller) runOnce() error {


### PR DESCRIPTION
The Kubernetes API server returns list responses in pages (default 500 objects per page). The controller was calling List() with no Limit or Continue parameters, silently processing only the first page and stopping.

In large clusters with many secrets, secrets beyond the first page were never processed — they remained permanently unpopulated with their SSM parameter values with no error or warning logged.

Fix: wrap the List() call in a pagination loop that sets Limit=500 and follows the Continue token returned by the API server until all pages are exhausted.