### PR TITLE
fix: use ResourceVersion=0 to prevent continue token expiry

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -63,8 +63,9 @@ func (c *Controller) HandleSecrets(cli kubernetes.Interface) error {
 
 	for {
 		secrets, err := cli.CoreV1().Secrets("").List(metav1.ListOptions{
-			Limit:    500,
-			Continue: continueToken,
+			Limit:           500,
+			Continue:        continueToken,
+			ResourceVersion: "0", // serve from the watch cache; tokens never expire
 		})
 		if err != nil {
 			log.Fatalf("Error retrieving secrets: %s", err)


### PR DESCRIPTION
When paginating a large list, the continue token is anchored to the etcd resource version at the time of the first List call. If the cycle takes longer than etcd's compaction window (~5 minutes), the token expires and the API returns HTTP 410 with:

  'The provided continue parameter is too old to display a consistent
  list result.'

Setting ResourceVersion="0" instructs the API server to serve the list from its in-memory watch cache instead of etcd directly. The watch cache tracks tokens by list ID rather than resource version, so they do not expire mid-pagination regardless of how long the cycle takes.

Side benefits:
- Lower API server and etcd load (cache hit)
- Faster response per page
- Slightly stale data (< 1s cache lag) is acceptable for this use case